### PR TITLE
Remove title from toc.

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -9,6 +9,6 @@ layout: base
 
 <script type="text/javascript">
     $(document).ready(function(){
-        $('.toc').tableOfContents();
+        $('.toc').tableOfContents(null, { startLevel: 2 } );
     });
 </script>


### PR DESCRIPTION
Not only do we get all the toc up one line, we also get all the toc left three columns.
Besides, the title already appears close to the toc.
