### PR TITLE
Added user contributed behaviours

### DIFF
--- a/cookbook/user-contributed-behaviors.markdown
+++ b/cookbook/user-contributed-behaviors.markdown
@@ -1,0 +1,25 @@
+---
+layout: documentation
+title: User-Contributed Behaviors
+---
+
+# User-Contributed Behaviors #
+
+Here is a list of Propel behaviors contributed by users. Feel free to use them or to add your own behaviors to this list.
+
+ * [EqualNestBehavior](http://github.com/CraftyShadow/EqualNestBehavior) Supports relations where a class references to itself and the columns within the reference class are equal. Suitable for "Friends"-like relationships.
+ 
+ * [sfPropelObjectPathBehaviorPlugin](http://www.symfony-project.org/plugins/sfPropelObjectPathBehaviorPlugin) Simplifies joining and handling relations deeper than one level. (Not Symfony specific)
+ 
+ * [ArrayAccessBehavior](http://github.com/nnarhinen/propel-arrayaccess) Adds ArrayAccess implementations to the BaseObjects
+ 
+ * [sfPropelActAsBlameableBehaviorPlugin](https://github.com/ArnaudD/sfPropelActAsBlameableBehaviorPlugin) Symfony plugin for Propel 1.5 to autofill created_by, updated_by and deleted_by columns
+ 
+ * [sfPropel15RatableBehaviorPlugin](https://github.com/matteosister/sfPropel15RatableBehaviorPlugin) A behavior for propel 1.5 and symfony to rate your objects.
+ 
+ * [sfPropel15TaggableBehaviorPlugin](https://github.com/matteosister/sfPropel15TaggableBehaviorPlugin) A behavior and a widget for propel 1.5 and symfony to tag your objects.
+ 
+ * [sfPropelLuceneableBehaviorPlugin](https://github.com/nibsirahsieu/sfPropelLuceneableBehaviorPlugin) A behavior for propel 1.6 and symfony 1.4 to enabled the model(s) to be searchable.
+ 
+ * [sfNestedCommentPlugin](https://github.com/nibsirahsieu/sfNestedCommentPlugin) A behavior for propel 1.5 and symfony to enabled the model(s) to be commentable.
+ 

--- a/documentation/07-behaviors.markdown
+++ b/documentation/07-behaviors.markdown
@@ -148,6 +148,8 @@ Propel currently bundles several behaviors. Check the behavior documentation for
 * [query_cache](../behaviors/query-cache)
 * And [concrete_inheritance](./09-inheritance), documented in the Inheritance Chapter even if it's a behavior
 
+You can also look at [user contributed behaviors](../cookbook/user-contributed-behaviors.html).
+
 Behaviors bundled with Propel require no further installation and work out of the box.
 
 ## Customizing Behaviors ##


### PR DESCRIPTION
Added the page that was in the old documentation about user contributed behaviours.

Currently I can assure that sfPropel15TaggableBehaviorPlugin works correctly with sf 1.4 and Propel 1.6.2, but I can assure that the rest will work.
