### PR TITLE
Target can be omitted when using lowercase for phing and propel libraries

### DIFF
--- a/cookbook/symfony2/working-with-symfony2.markdown
+++ b/cookbook/symfony2/working-with-symfony2.markdown
@@ -49,12 +49,10 @@ Add the following lines to your deps file (located in the root of the Symfony pr
     [PropelBundle]
         git=https://github.com/propelorm/PropelBundle.git
         target=/bundles/Propel/PropelBundle
-    [Phing]
+    [phing]
         git=https://github.com/Xosofox/phing
-        target=phing
-    [Propel]
+    [propel]
         git=https://github.com/propelorm/Propel.git
-        target=propel
     
 Update your vendor directory with
 


### PR DESCRIPTION
Since all the other non-bundle libraries in the Symfony2 deps file use lowercase vendor names and thus omit the "target" value, I think of this as a kind of best practice.

Examples:

[symfony]
    git=http://github.com/symfony/symfony.git
    version=v2.0.4

[twig]
    git=http://github.com/fabpot/Twig.git
    version=v1.1.2

[monolog]
    git=http://github.com/Seldaek/monolog.git
    version=1.0.1

Instead of e.g.:
[Monolog]
    git=http://github.com/Seldaek/monolog.git
    target=monolog
    version=1.0.1

All in all I think using lowercase names and leaving out the target value is not only shorter but also less error-prone.
