### PR TITLE
documentation bugfix in "Joining Tables" section

### DIFF
--- a/reference/model-criteria.markdown
+++ b/reference/model-criteria.markdown
@@ -634,7 +634,7 @@ WHERE book.TITLE = :p1'   // :p1 => 'War and Peace'
 {% highlight php %}
 <?php
 // Test data
-$author1 = new Book();
+$author1 = new Author();
 $author1->setName('Jane Austen');
 $author1->save();
 $book1 = new Book();


### PR DESCRIPTION
There is a incorrect line into a code example in "Joining Tables" section:

$author1 = new Book();

It should be:

$author1 = new Author();
