### PR TITLE
Update documentation/10-migrations.markdown

### DIFF
--- a/documentation/10-migrations.markdown
+++ b/documentation/10-migrations.markdown
@@ -100,7 +100,6 @@ Finally, in order to use the newly added table in application development, the d
 
 {% highlight text %}
 > propel-gen om
-
 {% endhighlight %}
 
 After a few days, the developer wants to add a new `author` table, with a foreign key in the `book` table. The schema is modified as follows:

--- a/documentation/10-migrations.markdown
+++ b/documentation/10-migrations.markdown
@@ -17,6 +17,7 @@ The workflow of Propel migrations is very simple:
 2. Call the `diff` task to create a migration class containing the SQL statements altering the database structure
 3. Review the migration class Propel just generated, and add data migration code if necessary
 4. Execute the migration using the `migrate` task.
+5. Call the `om` task to generate the updated object model classes.
 
 Here is a concrete example. On a new bookstore project, a developer creates an XML schema with a single `book` table:
 
@@ -94,6 +95,13 @@ Now, to actually create the `book` table in the database, the developer has to c
 {% endhighlight %}
 
 The `book` table is now created in the database. It can be populated with data.
+
+Finally, in order to use the newly added table in application development, the developer has to call the `om` task to generate the updated object model classes:
+
+{% highlight text %}
+> propel-gen om
+
+{% endhighlight %}
 
 After a few days, the developer wants to add a new `author` table, with a foreign key in the `book` table. The schema is modified as follows:
 


### PR DESCRIPTION
As per issue #251, submitting pull request adding instructions for final step of migration process--generating the new object model.

This adds text to two places: 
1. adds a fifth step to the short list of steps
2. adds the fifth step to the concrete example below the short list

https://github.com/propelorm/Propel/issues/251#issuecomment-3395513

Original text from issue #251 below:

If I needed to make a change to the database, for example add a column to a table, the current documentation says to do the following:
1. Modify the database schema in the schema.xml file.
2. Run 'propel-gen diff' to generate the migration file/class.
3. Edit the migration file/class, if necessary.
4. Run 'propel-gen migrate' to apply the changes to the database.

However, if I only do those steps, my object model will be out of sync with the schema and will still have no knowledge of the new column (this would be even worse if I wanted to remove a column from the schema, in which case queries still using that old column would actually fail and bring my site to a halt).

That said, I'm pretty sure that the "missing 5th step" should be:

(5) Run 'propel-gen om' to generate the updated object model classes.

(Note: I specified 'propel-gen om' and not the "triple-action" command of just 'propel-gen' without any parameters, because we specifically do not want to regenerate the sql file, and we also have no need to reconvert the runtime configuration file since that wouldn't have changed.)
