### PR TITLE
Update cookbook/symfony1/init-a-Symfony-project-with-Propel-git-way.mark...

### DIFF
--- a/cookbook/symfony1/init-a-Symfony-project-with-Propel-git-way.markdown
+++ b/cookbook/symfony1/init-a-Symfony-project-with-Propel-git-way.markdown
@@ -48,14 +48,14 @@ git submodule update --init
 You should add a `.gitignore` file with the following content:
 
 {% highlight bash %}
-/config/databases.yml
-/cache/*
-/log/*
-/data/sql/*
-/lib/filter/base/*
-/lib/form/base/*
-/lib/model/map/*
-/lib/model/om/*
+config/databases.yml
+cache/*
+log/*
+data/sql/*
+lib/filter/base/*
+lib/form/base/*
+lib/model/map/*
+lib/model/om/*
 {% endhighlight %}
 
 Now, enable `sfPropelORMPlugin` in `config/ProjectConfiguration.class.php`:


### PR DESCRIPTION
symfony is commonly installed in lib/vendor/symfony instead of lib/vendor. Source: http://www.symfony-project.org/jobeet/1_4/Propel/en/01

I put leading slashes for the .gitignore to look relative to the project directory
