### PR TITLE
Added PropelEventBundle to cookbook/user-contributed-behaviors

### DIFF
--- a/cookbook/user-contributed-behaviors.markdown
+++ b/cookbook/user-contributed-behaviors.markdown
@@ -36,6 +36,6 @@ Here is a list of Propel behaviors contributed by users. Feel free to use them o
 
 * [sfContextBehavior](https://github.com/Carpe-Hora/sfContextBehavior) A behavior for propel 1.6 and symfony 1.x redering object context aware.
 
-## symfony2 2.x Behaviors ##
+## Symfony2 2.x Behaviors ##
 
 * [PropelEventBundle](https://bitbucket.org/glorpen/glorpenpropeleventbundle) Add a way of using Symfony2 DIC in Propel model classes through events.


### PR DESCRIPTION
I didn't found a clean way to access Symfony2 DIC from propel classes so i wrote own. Supports lazy loading & usage from any propel class... or even any/no class.
