### PR TITLE
Added maxLength and offset to stream_get_contents to BLOB example

### DIFF
--- a/cookbook/working-with-advanced-column-types.markdown
+++ b/cookbook/working-with-advanced-column-types.markdown
@@ -22,7 +22,7 @@ BLOB values will be returned as PHP stream resources from the accessor methods. 
 $media = MediaPeer::retrieveByPK(1);
 $fp = $media->getCoverImage();
 if ($fp !== null) {
-  echo stream_get_contents($fp);
+  echo stream_get_contents($fp, -1, 0); // important to use 0 as offset so it works when being called multiple times
 }
 {% endhighlight %}
 


### PR DESCRIPTION
so peapple don't fall into the same problem I did.
If you try to use stream_get_contents($obj->getBlobField()) multiple times without using offset = 0, you will get "false" on the 2nd attempt and the following attempts since the cursor on the resource pointer has reached the end of the resource.
