### PR TITLE
Change tabs to spaces so that YAML configuration displays correctly.

### DIFF
--- a/cookbook/symfony2/working-with-symfony2.markdown
+++ b/cookbook/symfony2/working-with-symfony2.markdown
@@ -562,9 +562,9 @@ In case you want to use a different database for your ACL than your business mod
 
 ``` yaml
 services:
-    propel.security.acl.connection:
+        propel.security.acl.connection:
         class: PropelPDO
-        factory_class: Propel
+                factory_class: Propel
         factory_method: getConnection
         arguments:
             - "acl"


### PR DESCRIPTION
I'm using the online editor in github, and I'm not 100% sure it worked.  But the formatting in the current documentation at http://www.propelorm.org/cookbook/symfony2/working-with-symfony2.html, very bottom, doesn't render the YAML correctly.  That's what this is trying to fix.
