### PR TITLE
Fix commands to insert SQL

### DIFF
--- a/cookbook/symfony2/symfony2-and-propel-in-real-life.markdown
+++ b/cookbook/symfony2/symfony2-and-propel-in-real-life.markdown
@@ -83,10 +83,9 @@ You now have a usable `Product` class and all you need to persist it. Of course,
 Fortunately, Propel can automatically create all the database tables needed for every known entity in your application.
 To do this, run:
 
-    php app/console propel:sql:build
+    php app/console propel:build-sql
 
-    php app/console propel:sql:insert --force
-
+    php app/console propel:insert-sql --force
 
 Your database now has a fully-functional `product` table with columns that match the schema you've specified.
 


### PR DESCRIPTION
The commands to create the SQL were wrong.

Also, the message displayed after inserting the SQL is wrong

```
php app\console propel:insert-sql --force

  [Propel] You are running the command: propel:insert-sql
Use connection named default in dev environment.

  <info>All SQL statements have been generated.</info>
```

In fact, it should say All SQL statements have been executed.
