### PR TITLE
fix autoloader for Phing without composer

### DIFF
--- a/cookbook/symfony2/working-with-symfony2.markdown
+++ b/cookbook/symfony2/working-with-symfony2.markdown
@@ -130,7 +130,11 @@ $loader->registerNamespaces(array(
     ...
 
     'Propel' => __DIR__.'/../vendor/bundles',
-    'Phing'  => __DIR__.'/../vendor/phing/classes/phing',
+));
+$loader->registerPrefixes(array(
+    ...
+
+    'Phing' => __DIR__.'/../vendor/phing/classes/phing',
 ));
 {% endhighlight %}
 


### PR DESCRIPTION
It's not a class, but a "prefix" (actually, that's wrong too, but that one is working, as `Phing` is the entry point class and has all requires to move along).
