### PR TITLE
Without passing the variable $con and its default value, the error “Decl...

### DIFF
--- a/behaviors/versionable.markdown
+++ b/behaviors/versionable.markdown
@@ -119,7 +119,7 @@ You may not need a new version each time an object is created or modified. If yo
 <?php
 class Book extends BaseBook
 {
-  public function isVersioningNecessary()
+  public function isVersioningNecessary($con = null)
   {
     return $this->getISBN() !== null && parent::isVersioningNecessary();
   }


### PR DESCRIPTION
...aration of … should be compatible with that of …” shows up in PHP 5.3.
