### PR TITLE
Clarify ParamConverter section example with use statement

### DIFF
--- a/cookbook/symfony2/working-with-symfony2.markdown
+++ b/cookbook/symfony2/working-with-symfony2.markdown
@@ -583,6 +583,9 @@ You just need to put the right _Annotation_ on top of your controller:
 {% highlight php %}
 <?php
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+[...]
+
 /**
  * @ParamConverter("post", class="BlogBundle\Model\Post")
  */


### PR DESCRIPTION
I've added "use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;"
to the first ParamConverter example just to make it clear.
