### PR TITLE
Add text to indicate Migrations support for PostgreSQL

### DIFF
--- a/documentation/10-migrations.markdown
+++ b/documentation/10-migrations.markdown
@@ -7,7 +7,7 @@ title: Migrations
 
 During the life of a project, the Model seldom stays the same. New tables arise, and existing tables often need modifications (a new column, a new index, another foreign key...). Updating the database structure accordingly, while preserving existing data, is a common concern. Propel provides a set of tools to allow the _migration_ of database structure and data with ease.
 
->**Tip**<br />Propel only supports migrations in MySQL for now.
+>**Tip**<br />Propel only supports migrations in MySQL and PostgreSQL for now.
 
 ## Migration Workflow ##
 


### PR DESCRIPTION
If PostgreSQL is indeed supported (as indicated at the end of the Migrations Section of "What’s new in Propel 1.6?" - http://www.propelorm.org/documentation/whats-new.html), it should be indicated in the "Migrations" chapter of Propel Documentation.
Otherwise, could you please indicate what's preventing PostgreSQL from being supported?
