### PR TITLE
Update cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown

### DIFF
--- a/cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown
+++ b/cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown
@@ -500,7 +500,9 @@ To use it is in a `validation.yml` file just add those few lines in your validat
 {% highlight yaml %}
 BundleNamespace\Model\User:
   constraints:
-    - Propel\PropelBundle\Validator\Constraints\UniqueObject: username
+    - Propel\PropelBundle\Validator\Constraints\UniqueObject:
+      fields: username
+      message: User already exists ({{ fields }}).
 {% endhighlight %}
 
 In order to validate the unicity of more than just one fields:
@@ -508,7 +510,8 @@ In order to validate the unicity of more than just one fields:
 {% highlight yaml %}
 BundleNamespace\Model\User:
   constraints:
-    - Propel\PropelBundle\Validator\Constraints\UniqueObject: [username, login]
+    - Propel\PropelBundle\Validator\Constraints\UniqueObject:
+      fields: [username, login]
 {% endhighlight %}
 
 As many validator of this type as you want can be used.


### PR DESCRIPTION
Updated UniqueObject part to affect getDefaultOption() removal, which leads to Internal Server Error with previous example. Also shows how error message can be specified.

Commit and my comment:
https://github.com/propelorm/PropelBundle/commit/1b0c49c128635ea6276e60f18ef2cb29eaaa468b#commitcomment-2187035
