### PR TITLE
Fix a typo in customizing-build documentation page

### DIFF
--- a/cookbook/customizing-build.markdown
+++ b/cookbook/customizing-build.markdown
@@ -49,7 +49,7 @@ propel.database.url = sqlite://localhost/./test/bookstore.db
 propel.targetPackage = bookstore
 
 # directories
-prope.output.dir = /var/www/bookstore
+propel.output.dir = /var/www/bookstore
 propel.php.dir = ${propel.output.dir}/classes
 propel.phpconf.dir = ${propel.output.dir}/conf
 propel.sql.dir = ${propel.output.dir}/db/sql


### PR DESCRIPTION
The sample build.properties file given had a typo: `prope.output_dir` instead of `propel.output_dir`.
