### PR TITLE
Update documentation/08-logging.markdown

### DIFF
--- a/documentation/08-logging.markdown
+++ b/documentation/08-logging.markdown
@@ -168,7 +168,7 @@ class MyLogger implements BasicLogger
   public function log($message, $priority)
   {
     $color = $this->priorityToColor($priority);
-    echo '<p style="color: ' . $color . '">$message</p>';
+    echo '<p style="color: ' . $color . '">' . $message . '</p>';
   }
 
   private function priorityToColor($priority)


### PR DESCRIPTION
Without this edit the log will always output "$message" instead of the actual message.
