### PR TITLE
Correct typo in download.markdown

### DIFF
--- a/download.markdown
+++ b/download.markdown
@@ -13,7 +13,7 @@ Clone it:
 
 ```bash
 $ git clone git://github.com/propelorm/Propel.git
-```bash
+```
 
 Or add it as a submodule:
 


### PR DESCRIPTION
Simple typo.  Just fixing the formatting.
