### PR TITLE
Update 03-basic-crud.markdown

### DIFF
--- a/documentation/03-basic-crud.markdown
+++ b/documentation/03-basic-crud.markdown
@@ -157,7 +157,7 @@ $author = AuthorQuery::create()->findOneByFirstName('Jane');
 
 The Propel Query API is very powerful. The next chapter will teach you to use it to add conditions on related objects. If you can't wait, jump to the [Query API reference](../reference/model-criteria).
 
->**Tip**<br />The `findPk` and `findOneById` methods do not always query the database, but sometimes give you information from a cache. See the section about the [instance pool](#propel-instance-pool) for more information.
+>**Tip**<br />The `findPk` method and `findOneByXXX` magic methods (for primary key attributes) do not always query the database, but sometimes give you information from a cache. See the section about the [instance pool](#propel-instance-pool) for more information.
 
 ### Using Custom SQL ###
 


### PR DESCRIPTION
Added a note that calls to find\* methods do not always set off database queries and how to avoid that, if necessary.
As an example given, the case is proposed where the objects values have been overridden due to binding it to a form. In this case, using find\* to get the old values from the database won't work, since the instance pool serves the query with the current object.
