### PR TITLE
Documentation - Replacing bindRequest which is deprecated by handleRequest

### DIFF
--- a/cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown
+++ b/cookbook/symfony2/mastering-symfony2-forms-with-propel.markdown
@@ -133,7 +133,7 @@ then persisting it after a form submission can be done when the form is valid:
         $request = $this->getRequest();
 
         if ('POST' === $request->getMethod()) {
-            $form->bindRequest($request);
+            $form->handleRequest($request);
 
             if ($form->isValid()) {
                 $book->save();


### PR DESCRIPTION
The official Symfony2 documentation recommends the use of handleRequest instead of bindRequest which seems to be deprecated, like bind and submit.
http://symfony.com/doc/current/book/forms.html#handling-form-submissions
