### PR TITLE
Update sluggable.markdown to fix formatting issues.

### DIFF
--- a/behaviors/sluggable.markdown
+++ b/behaviors/sluggable.markdown
@@ -10,6 +10,7 @@ The `sluggable` behavior allows a model to offer a human readable identifier tha
 ## Basic Usage ##
 
 In the `schema.xml`, use the `<behavior>` tag to add the `sluggable` behavior to a table:
+
 ```xml
 <table name="post">
   <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />


### PR DESCRIPTION
The first paragraph tag under "Basic Usage" contains a code block which needs to be outside of the paragraph to be formatted correctly.
![formatting_issue](https://f.cloud.github.com/assets/203576/1016692/0d65d828-0c00-11e3-9108-04248498dde5.jpg)
