### PR TITLE
Fixed code block markup

### DIFF
--- a/behaviors/timestampable.markdown
+++ b/behaviors/timestampable.markdown
@@ -10,6 +10,7 @@ The `timestampable` behavior allows you to keep track of the date of creation an
 ## Basic Usage ##
 
 In the `schema.xml`, use the `<behavior>` tag to add the `timestampable` behavior to a table:
+
 ```xml
 <table name="book">
   <column name="id" required="true" primaryKey="true" autoIncrement="true" type="integer" />


### PR DESCRIPTION
Otherwise, it's rendered as an inline code block: http://propelorm.org/behaviors/timestampable.html
