### PR TITLE
Fixing typo in AND/OR clause example

### DIFF
--- a/_posts/2010-02-16-propel-query-by-example.markdown
+++ b/_posts/2010-02-16-propel-query-by-example.markdown
@@ -96,7 +96,7 @@ $article = ArticleQuery::create()
 // Propel 1.4
 $c = new Criteria();
 $cton1 = $c->getNewCriterion(ArticlePeer::TITLE, '%FooBar%', Criteria::LIKE);
-$cton1 = $c->getNewCriterion(ArticlePeer::SUMMARY, '%FooBar%', Criteria::LIKE);
+$cton2 = $c->getNewCriterion(ArticlePeer::SUMMARY, '%FooBar%', Criteria::LIKE);
 $cton1->addOr($cton2);
 $c->add($cton1);
 $c->add(ArticlePeer::PUBLISHED_AT, $begin, Criteria::GREATER_THAN);


### PR DESCRIPTION
The subcriteria's used for the example weren't properly defined.  Missing $cton2, fixed that in examples.
