### PR TITLE
broken link to i18n behavior docs

### DIFF
--- a/_posts/2011-01-11-propel-gets-i18n-behavior-and-why-it-matters.markdown
+++ b/_posts/2011-01-11-propel-gets-i18n-behavior-and-why-it-matters.markdown
@@ -113,4 +113,4 @@ WHERE item_i18n.locale = 'en_EN';</pre></div>
 </ul>
 <p><strong>Tip</strong>: If you need to return only objects having translations, add <code>Criteria::INNER_JOIN</code> as second parameter to <code>joinWithI18n()</code>.</p>
 <h3>Get It</h3>
-<p>Just like the recently added <code>versionable</code> behavior, the <code>i18n</code> behavior is thoroughly unit-tested and <a href="http://www.propelorm.org/wiki/Documentation/1.6/Behaviors/i18n">fully documented</a>. It is ready to use in the Propel 1.6 branch, and your multilingual applications will love it.</p>
+<p>Just like the recently added <code>versionable</code> behavior, the <code>i18n</code> behavior is thoroughly unit-tested and <a href="http://propelorm.org/behaviors/i18n">fully documented</a>. It is ready to use in the Propel 1.6 branch, and your multilingual applications will love it.</p>


### PR DESCRIPTION
Updated the link, maybe would be useful to update the whole doc, but for now it's good to at least provide an usable link to the docs reference.
