### PR TITLE
add table order behavior to user contributed behavior list

### DIFF
--- a/documentation/cookbook/user-contributed-behaviors.markdown
+++ b/documentation/cookbook/user-contributed-behaviors.markdown
@@ -13,3 +13,5 @@ Here is a list of Propel behaviors contributed by users. Feel free to use them o
 * [EqualNestBehavior](http://github.com/CraftyShadow/EqualNestBehavior) Supports relations where a class references to itself and the columns within the reference class are equal. Suitable for "Friends"-like relationships.
 
 * [ArrayAccessBehavior](http://github.com/nnarhinen/propel-arrayaccess) Adds ArrayAccess implementations to the BaseObjects
+
+* [DefaultOrderBehavior](https://github.com/gharlan/propel-default-order-behavior) Adds support for user defined order for tables.


### PR DESCRIPTION
I was not sure about the heading for this behavior. In my opinion it fits not into agnostic behaviors. Couldn't decide about order or sort behavior. Maybe someone else has a better idea for the heading?

fixes #305
