### PR TITLE
Update contribute.markdown

### DIFF
--- a/contribute.markdown
+++ b/contribute.markdown
@@ -68,7 +68,7 @@ button. Add a short description to this Pull Request and submit it.
 Please make sure our test suite is still green and you wrote an adequate test that
 covers your changes.
 
-You can get more information in our cookbook article: [Working with Propel's Test Suite](/documentation/cookbook/working-with-test-suite.html).
+You can get more information in our cookbook article: [Working with Propel's Test Suite](http://propelorm.org/documentation/cookbook/working-with-test-suite.html).
 
 ## Improve the documentation ##
 


### PR DESCRIPTION
use abs link to otherwise link [1] in github does not work. link to it is present in Propel2 README.md [2]

[1] https://github.com/propelorm/propelorm.github.com/blob/master/contribute.markdown
[2] https://github.com/propelorm/Propel2#contribute
