### PR TITLE
Update needed Symfony2 installation dependencies

### DIFF
--- a/documentation/cookbook/symfony2/working-with-symfony2.markdown
+++ b/documentation/cookbook/symfony2/working-with-symfony2.markdown
@@ -15,7 +15,7 @@ The recommended way to install this bundle is to rely on
 
 ``` json
 "require": {
-    "propel/propel": "2.0.*@dev"
+    "propel/propel": "2.0.*@dev",
     "propel/propel-bundle": "~2.0@dev"
 }
 ```

--- a/documentation/cookbook/symfony2/working-with-symfony2.markdown
+++ b/documentation/cookbook/symfony2/working-with-symfony2.markdown
@@ -15,6 +15,7 @@ The recommended way to install this bundle is to rely on
 
 ``` json
 "require": {
+    "propel/propel": "2.0.*@dev"
     "propel/propel-bundle": "~2.0@dev"
 }
 ```


### PR DESCRIPTION
Currently, installing the bundle with just the `"propel/propel-bundle": "~2.0@dev"` dependency get the last propel/propel 1.x version. We have to explicitly add the `"propel/propel": "2.0.*@dev"` require statement.