### PR TITLE
Update documentation for PHP-5.5.

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Page not Found - Propel, The Blazing Fast Open-Source PHP 5.4 ORM</title>
+    <title>Page not Found - Propel, The Blazing Fast Open-Source PHP 5.5 ORM</title>
     <meta name="language" content="en" >
     <meta http-equiv="content-type" content="text/html; charset=utf-8" >
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" >
@@ -25,7 +25,7 @@
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
       ga('create', 'UA-70372452-1', 'auto');
       ga('send', 'pageview');
     </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,4 @@
-<title>{% if page.title %} {{ page.title }} - {% endif %}Propel, The Blazing Fast Open-Source PHP 5.4 ORM</title>
+<title>{% if page.title %} {{ page.title }} - {% endif %}Propel, The Blazing Fast Open-Source PHP 5.5 ORM</title>
 <meta name="language" content="en" >
 <meta http-equiv="content-type" content="text/html; charset=utf-8" >
 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" >

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,7 +4,7 @@ layout: base
 
 <div class="home-banner">
     <h2>A highly customizeable and blazing fast
-    <strong>ORM</strong> library for PHP 5.4+.</h2>
+    <strong>ORM</strong> library for PHP 5.5+.</h2>
 
     <div class="home-buttons">
         <a class="button" href="http://sandbox.propelorm.org/example/bookstore" target="_blank">Demo in sandbox</a><a

--- a/documentation/01-installation.markdown
+++ b/documentation/01-installation.markdown
@@ -11,7 +11,7 @@ Propel is available as a clone from the official [Github repository](http://gith
 
 Propel just requires:
 
-* [PHP 5.4](http://www.php.net/) or newer, with the DOM (libxml2) module enabled
+* [PHP 5.5](http://www.php.net/) or newer, with the DOM (libxml2) module enabled
 * A supported database (MySQL, MS SQL Server, PostgreSQL, SQLite, Oracle)
 
 Propel also uses some Symfony2 components to work properly:

--- a/documentation/cookbook/silex/working-with-silex.markdown
+++ b/documentation/cookbook/silex/working-with-silex.markdown
@@ -17,7 +17,7 @@ Set up
 If you want to use *PropelServiceProvider*, you will need:
 
   * Silex 1.x
-  * PHP 5.4 or greater
+  * PHP 5.5 or greater
   * Composer
 
 To setup the project in your Silex application, you have to rely on composer ;

--- a/documentation/reference/compatibility-index.markdown
+++ b/documentation/reference/compatibility-index.markdown
@@ -17,7 +17,7 @@ At the moment we list only MySQL, SQLite and Postgres since only those are unit 
 
 |  Functionality   |  MySQL |   SQLite    | Postgres
 |------------------|--------|-------------|---------
-| General          |   Yes  |  Partial(1) |    Yes 
+| General          |   Yes  |  Partial(1) |    Yes
 | `name` attribute |   Yes  |  No(2)      |    Yes
 
 1) As of version 3.6.19, SQLite supports foreign key constraints.
@@ -43,12 +43,4 @@ we're setting primaryKey=false and create a unique constraint instead, which is 
 
 ## PHP Versions
 
-### < 5.4.9 with PostgreSQL
-
-If you're using < 5.4.9 and PostgreSQL you can't use `ATTR_EMULATE_PREPARES` due to a [bug in PHP's PDO](https://bugs.php.net/bug.php?id=62593) that throws errors like:
-
-```
-column COLUMN is of type boolean but expression is of type integer
-```
-
-Update PHP to a newer version or disable `ATTR_EMULATE_PREPARES`.
+Update PHP to version 5.5 or upper.

--- a/index.markdown
+++ b/index.markdown
@@ -28,7 +28,7 @@ All releases at github.com: [github.com/propelorm/Propel2/releases](https://gith
 
 ### What is Propel exactly? ###
 
-Propel is an open-source Object-Relational Mapping (ORM) for SQL-Databases in PHP 5.4.
+Propel is an open-source Object-Relational Mapping (ORM) for SQL-Databases in PHP 5.5.
 It allows you to access your database using a set of objects, providing a simple API for storing and retrieving data.
 
 Additional to its ORM capabilities it does provide a **query-builder**, **database schema migration**, **reverse engineering** of existing database and much more.
@@ -41,7 +41,7 @@ other classes and objects in PHP without writing SQL.
 * Propel is blazing fast
 * Query-Builder
 * IDE friendly thanks to code-generation
-* Generation of methods for all columns and **relations** 
+* Generation of methods for all columns and **relations**
 * Database schema migration
 * Schema reverse engineering
 * Customizable
@@ -50,7 +50,7 @@ other classes and objects in PHP without writing SQL.
 
 ### How? ###
 
-You need to write the definition of your tables as xml, export it from your existing database through our 'database:reverse' command or 
+You need to write the definition of your tables as xml, export it from your existing database through our 'database:reverse' command or
 build it via a tool like ORM-Designer.
 
 ```xml


### PR DESCRIPTION
As Propel2 is not tested against PHP-5.4, the minimum requirement is
5.5.