### PR TITLE
Update propel bundle AppKernel class namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
+gem 'pygments.rb'

--- a/documentation/cookbook/symfony2/working-with-symfony2.markdown
+++ b/documentation/cookbook/symfony2/working-with-symfony2.markdown
@@ -29,7 +29,7 @@ public function registerBundles()
 {
     $bundles = array(
         // ...
-        new Propel\PropelBundle\PropelBundle(),
+        new Propel\Bundle\PropelBundle\PropelBundle(),
     );
 
     // ...


### PR DESCRIPTION
PropelBundle use different namespace than described here in documentation.