### PR TITLE
Change MySQL coding from `utf8` to `utf8mb4`

### DIFF
--- a/documentation/02-buildtime.markdown
+++ b/documentation/02-buildtime.markdown
@@ -335,9 +335,9 @@ propel:
       default:
         adapter: mysql
         settings:
-          charset: utf8
+          charset: utf8mb4
           queries:
-            utf8: "SET NAMES utf8 COLLATE utf8_unicode_ci, COLLATION_CONNECTION = utf8_unicode_ci, COLLATION_DATABASE = utf8_unicode_ci, COLLATION_SERVER = utf8_unicode_ci"
+            utf8: "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci, COLLATION_CONNECTION = utf8mb4_unicode_ci, COLLATION_DATABASE = utf8mb4_unicode_ci, COLLATION_SERVER = utf8mb4_unicode_ci"
 {% endhighlight %}
 </div>
 <div id="tabPgsql">


### PR DESCRIPTION
In MySQL, the `utf8` charset and collation actually only implement a part of the whole UTF-8 encoding. The `utf8mb4` collation and charset implement all possible UTF-8 text as this one does support 4 bytes. This change would prevent mishaps with UTF-8 which are all too common. See https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html