### PR TITLE
change overflow to auto

### DIFF
--- a/css/base_syntax.css
+++ b/css/base_syntax.css
@@ -1,7 +1,6 @@
 .highlight {
     background-color: #E7EFF5;
     margin: 20px 0 20px 0;
-    overflow: hidden;
 
     border-radius: 4px;
     -webkit-border-radius: 4px;

--- a/css/markdown.css
+++ b/css/markdown.css
@@ -64,7 +64,6 @@
     font-family: "Bitstream Vera Sans Mono", monospace;
     padding: 5px;
     max-width: 100%;
-    overflow-y: auto;
 }
 
 .markdown blockquote {


### PR DESCRIPTION
Fix the problem that cannot scroll in a smaller resolution (ex: iPhone) with the previous overflow setting

I couldn't scroll in x-direction in my iPhone, it let me cannot see some code in the document