### PR TITLE
Add a note ➡ config:convert

### DIFF
--- a/documentation/10-configuration.markdown
+++ b/documentation/10-configuration.markdown
@@ -7,7 +7,7 @@ title: Configuration
 Propel asks you to define some data to work properly, for instance: connection parameters, working directories, flags to take decisions and so on.
 You can pass these data via a *configuration file*.
 
-*Note* : Configuration files are used to generate a configuration class (```generated-conf/config.php``). Any changes made to the configuration file need to be pushed to this generated configuration file through the ```vendor/bin/propel config:convert``` propel command.
+*Note* : Configuration files are used to generate a configuration class (`generated-conf/config.php`). Any changes made to the configuration file need to be pushed to this generated configuration file through the `vendor/bin/propel config:convert` command.
 
 Propel configuration file simply describes an associative array of properties, with a well defined hierarchy. See [Configuration reference](/documentation/reference/configuration-file.html) for the complete list.
 

--- a/documentation/10-configuration.markdown
+++ b/documentation/10-configuration.markdown
@@ -7,6 +7,8 @@ title: Configuration
 Propel asks you to define some data to work properly, for instance: connection parameters, working directories, flags to take decisions and so on.
 You can pass these data via a *configuration file*.
 
+*Note* : Configuration files are used to generate a configuration class (```generated-conf/config.php``). Any changes made to the configuration file need to be pushed to this generated configuration file through the ```vendor/bin/propel config:convert``` propel command.
+
 Propel configuration file simply describes an associative array of properties, with a well defined hierarchy. See [Configuration reference](/documentation/reference/configuration-file.html) for the complete list.
 
 Propel configuration sub-system is based on [Symfony Config Component](http://symfony.com/doc/current/components/config/index.html).


### PR DESCRIPTION
I think we need to draw more attention to this feature - if you've written your config file, the only place where config:convert is mentioned is in Building a project.  I read through this document and as I was working with an existing database,  read through 'the easy way'

I suggest that  as this is such an important aspect of the configuration, that this section be moved to it's own file, so that it can be referenced from the build docs here, and also from the configuration section - which  is also missing this information.