### PR TITLE
update minimum required php version

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Page not Found - Propel, The Blazing Fast Open-Source PHP 5.5 ORM</title>
+    <title>Page not Found - Propel, The Blazing Fast Open-Source PHP 7.4 ORM</title>
     <meta name="language" content="en" >
     <meta http-equiv="content-type" content="text/html; charset=utf-8" >
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" >

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,4 @@
-<title>{% if page.title %} {{ page.title }} - {% endif %}Propel, The Blazing Fast Open-Source PHP 5.5 ORM</title>
+<title>{% if page.title %} {{ page.title }} - {% endif %}Propel, The Blazing Fast Open-Source PHP 7.4 ORM</title>
 <meta name="language" content="en" >
 <meta http-equiv="content-type" content="text/html; charset=utf-8" >
 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" > 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,7 +4,7 @@ layout: base
 
 <div class="home-banner">
     <h2>A highly customizable and blazing fast
-    <strong>ORM</strong> library for PHP 5.5+.</h2>
+    <strong>ORM</strong> library for PHP 7.4+.</h2>
 
     <div class="home-buttons">
         <a class="button" href="http://sandbox.propelorm.org/example/bookstore" target="_blank">Demo in sandbox</a><a

--- a/documentation/cookbook/silex/working-with-silex.markdown
+++ b/documentation/cookbook/silex/working-with-silex.markdown
@@ -17,7 +17,7 @@ Set up
 If you want to use *PropelServiceProvider*, you will need:
 
   * Silex 1.x
-  * PHP 5.5 or greater
+  * PHP 7.4 or greater
   * Composer
 
 To setup the project in your Silex application, you have to rely on composer ;

--- a/documentation/reference/compatibility-index.markdown
+++ b/documentation/reference/compatibility-index.markdown
@@ -43,4 +43,4 @@ we're setting primaryKey=false and create a unique constraint instead, which is 
 
 ## PHP Versions
 
-Update PHP to version 5.5 or upper.
+Update PHP to version 7.4 or upper.

--- a/index.markdown
+++ b/index.markdown
@@ -28,7 +28,7 @@ All releases at github.com: [github.com/propelorm/Propel2/releases](https://gith
 
 ### What is Propel exactly? ###
 
-Propel is an open-source Object-Relational Mapping (ORM) for SQL-Databases in PHP 5.5.
+Propel is an open-source Object-Relational Mapping (ORM) for SQL-Databases in PHP 7.4.
 It allows you to access your database using a set of objects, providing a simple API for storing and retrieving data.
 
 Additional to its ORM capabilities it does provide a **query-builder**, **database schema migration**, **reverse engineering** of existing database and much more.


### PR DESCRIPTION
The Propel 2 Readme lists PHP 7.4, so I've updated this on the website.