### PR TITLE
PHP update from 5.5 to 8

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,4 @@
-<title>{% if page.title %} {{ page.title }} - {% endif %}Propel, The Blazing Fast Open-Source PHP 5.5 ORM</title>
+<title>{% if page.title %} {{ page.title }} - {% endif %}Propel, The Blazing Fast Open-Source PHP8 ORM</title>
 <meta name="language" content="en" >
 <meta http-equiv="content-type" content="text/html; charset=utf-8" >
 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" > 

--- a/index.markdown
+++ b/index.markdown
@@ -28,7 +28,7 @@ All releases at github.com: [github.com/propelorm/Propel2/releases](https://gith
 
 ### What is Propel exactly? ###
 
-Propel is an open-source Object-Relational Mapping (ORM) for SQL-Databases in PHP 5.5.
+Propel is an open-source Object-Relational Mapping (ORM) for SQL-Databases in PHP8.
 It allows you to access your database using a set of objects, providing a simple API for storing and retrieving data.
 
 Additional to its ORM capabilities it does provide a **query-builder**, **database schema migration**, **reverse engineering** of existing database and much more.


### PR DESCRIPTION
The title and description in the headers of the website still mentioned PHP 5.5, which caused this to also show in the Google SERPs (see screenshot)
![SCR-20240507-tigq](https://github.com/propelorm/propelorm.github.com/assets/487722/c1b35c75-9f7d-4550-98fc-56c660b00312)

Updated the texts to reflect that this is now PHP8.